### PR TITLE
Add a WakeLock to prevent sleeping during bootloader programming.

### DIFF
--- a/software/applications/IOIOManager/AndroidManifest.xml
+++ b/software/applications/IOIOManager/AndroidManifest.xml
@@ -4,6 +4,7 @@
 	<uses-sdk android:minSdkVersion="3" />
 	<uses-permission android:name="android.permission.INTERNET" />
 	<uses-permission android:name="android.permission.BLUETOOTH" />
+	<uses-permission android:name="android.permission.WAKE_LOCK" />
 
 	<application android:icon="@drawable/ic_launcher"
 		android:label="@string/app_name">


### PR DESCRIPTION
Currently the ProgrammerActivity doesn't keep the system from sleeping during programming or erasing or verifying. This change adds a WakeLock that's held while the manager is programming, erasing, or verifying.
