### PR TITLE
Fix for protocol_defs.h I2C_WRITE_READ_ARGS field order

### DIFF
--- a/firmware/app_layer_v1/protocol_defs.h
+++ b/firmware/app_layer_v1/protocol_defs.h
@@ -262,8 +262,8 @@ typedef struct PACKED {
 // i2c write read
 typedef struct PACKED {
   BYTE i2c_num : 2;
-  BYTE ten_bit_addr : 1;
   BYTE : 3;
+  BYTE ten_bit_addr : 1;
   BYTE addr_msb : 2;
   BYTE addr_lsb;
   BYTE write_size;


### PR DESCRIPTION
This moves the ten_bit_addr bit to the correct position as reflected in software/IOIOLib/src/ioio/lib/impl/IOIOProtocol.java:283
