### PR TITLE
Updated the compiler target api to android-19 for IOIOLib, and fixed all...

### DIFF
--- a/software/IOIOLib/src/ioio/lib/impl/SocketIOIOConnectionBootstrap.java
+++ b/software/IOIOLib/src/ioio/lib/impl/SocketIOIOConnectionBootstrap.java
@@ -42,7 +42,7 @@ public class SocketIOIOConnectionBootstrap implements IOIOConnectionBootstrap {
 	@Override
 	public void getFactories(Collection<IOIOConnectionFactory> result) {
 		result.add(new IOIOConnectionFactory() {
-			private Integer port_ = new Integer(IOIO_PORT);
+			private Integer port_ = Integer.valueOf(IOIO_PORT);
 			
 			@Override
 			public String getType() {

--- a/software/IOIOLib/src/ioio/lib/impl/SpiMasterImpl.java
+++ b/software/IOIOLib/src/ioio/lib/impl/SpiMasterImpl.java
@@ -36,8 +36,6 @@ import ioio.lib.impl.IncomingState.DataModuleListener;
 import ioio.lib.spi.Log;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
@@ -79,7 +77,6 @@ class SpiMasterImpl extends AbstractResource implements SpiMaster,
 			this);
 
 	private final int spiNum_;
-	private final Map<Integer, Integer> ssPinToIndex_;
 	private final int[] indexToSsPin_;
 	private final int mosiPinNum_;
 	private final int misoPinNum_;
@@ -93,10 +90,6 @@ class SpiMasterImpl extends AbstractResource implements SpiMaster,
 		misoPinNum_ = misoPinNum;
 		clkPinNum_ = clkPinNum;
 		indexToSsPin_ = ssPins.clone();
-		ssPinToIndex_ = new HashMap<Integer, Integer>(ssPins.length);
-		for (int i = 0; i < ssPins.length; ++i) {
-			ssPinToIndex_.put(ssPins[i], i);
-		}
 	}
 
 	@Override

--- a/software/IOIOLib/target/android/AndroidManifest.xml
+++ b/software/IOIOLib/target/android/AndroidManifest.xml
@@ -4,5 +4,6 @@
       android:versionCode="1"
       android:versionName="1.0">
 
-	<uses-permission android:name="android.permission.INTERNET"></uses-permission>
-</manifest> 
+	<uses-permission android:name="android.permission.INTERNET" />
+	<uses-sdk android:minSdkVersion="3" />
+</manifest>

--- a/software/IOIOLib/target/android/project.properties
+++ b/software/IOIOLib/target/android/project.properties
@@ -9,4 +9,4 @@
 
 android.library=true
 # Project target.
-target=android-3
+target=android-7

--- a/software/IOIOLib/target/android/src/ioio/lib/util/android/IOIOService.java
+++ b/software/IOIOLib/target/android/src/ioio/lib/util/android/IOIOService.java
@@ -95,13 +95,7 @@ public abstract class IOIOService extends Service implements
 		super.onDestroy();
 	}
 
-	/**
-	 * Subclasses should call this method from their own onStart() if
-	 * overloaded. It takes care of connecting with the IOIO.
-	 */
-	@Override
-	public void onStart(Intent intent, int startId) {
-		super.onStart(intent, startId);
+	private void start(Intent intent) {
 		if (!started_) {
 			helper_.start();
 			started_ = true;
@@ -110,6 +104,28 @@ public abstract class IOIOService extends Service implements
 				helper_.restart();
 			}
 		}
+	}
+
+	/**
+	 * This is the old onStart() method. Override and/or call this method only
+	 * if you're using Android API level lower than 5. Otherwise you shoud call
+	 * the onStartCommand() method.
+	 */
+	@Override
+	public void onStart(Intent intent, int startId) {
+		start(intent);
+	}
+
+	/**
+	 * Subclasses should call this method from their own onStartCommand() if
+	 * overloaded. It takes care of connecting with the IOIO.
+	 */
+	@Override
+	public int onStartCommand(Intent intent, int flags, int startId) {
+		start(intent);
+		// We want this service to continue running until it is explicitly
+		// stopped, so return sticky.
+		return START_STICKY;
 	}
 
 	/**


### PR DESCRIPTION
... lint/deprecation related warnings. (left minimum SDK for compilation at 3).

Hey Ytai,

This is the first step in "squashing" all libraries into 1.
I put it to compile against SDK19, just because it's the newest. I don't think there's any reason to go lower, even though we don't use anything that is newer than SDK15... but let me know what you think.

Thanks.
