### PR TITLE
IOIOImpl: obey IOIOConnection.canClose()

### DIFF
--- a/software/IOIOLib/src/ioio/lib/impl/IOIOImpl.java
+++ b/software/IOIOLib/src/ioio/lib/impl/IOIOImpl.java
@@ -120,6 +120,7 @@ public class IOIOImpl implements IOIO, DisconnectListener {
 						throw new ConnectionLostException();
 					}
 					protocol_ = new IOIOProtocol(connection_.getInputStream(),
+								     connection_.canClose(),
 							connection_.getOutputStream(), incomingState_);
 					// Once this block exits, a disconnect will also involve
 					// softClose().

--- a/software/IOIOLib/src/ioio/lib/impl/IOIOProtocol.java
+++ b/software/IOIOLib/src/ioio/lib/impl/IOIOProtocol.java
@@ -941,7 +941,8 @@ class IOIOProtocol {
 				Log.e(TAG, "Protocol error: ", new ProtocolError(e));
 			} finally {
 				try {
-					in_.close();
+					if (canClose_)
+						in_.close();
 				} catch (IOException e) {
 				}
 				handler_.handleConnectionLost();
@@ -950,12 +951,14 @@ class IOIOProtocol {
 	}
 
 	private final InputStream in_;
+	private final boolean canClose_;
 	private final OutputStream out_;
 	private final IncomingHandler handler_;
 	private final IncomingThread thread_ = new IncomingThread();
 
-	public IOIOProtocol(InputStream in, OutputStream out, IncomingHandler handler) {
+	public IOIOProtocol(InputStream in, boolean canClose, OutputStream out, IncomingHandler handler) {
 		in_ = in;
+		canClose_ = canClose;
 		out_ = out;
 		handler_ = handler;
 		thread_.start();

--- a/software/IOIOLibAccessory/src/ioio/lib/android/accessory/AccessoryConnectionBootstrap.java
+++ b/software/IOIOLibAccessory/src/ioio/lib/android/accessory/AccessoryConnectionBootstrap.java
@@ -269,7 +269,7 @@ public class AccessoryConnectionBootstrap extends BroadcastReceiver implements
 		public void disconnect() {
 			synchronized (AccessoryConnectionBootstrap.this) {
 				instanceState_ = InstanceState.DEAD;
-				AccessoryConnectionBootstrap.this.notifyAll();
+				AccessoryConnectionBootstrap.this.close();
 			}
 		}
 


### PR DESCRIPTION
Fixes reconnect errors in "accessory" mode.  The InputStream.close()
call in IOIOProtocol.IncomingThread.run() closes the USB accessory
file descriptor without telling AccessoryConnectionBootstrap.  That
class will never notice the file descriptor was invalidated, and will
repeatedly try using it, each time failing with EBADF.

By obeying IOIOConnection.canClose(), the existing file descriptor can
be reused.
