### PR TITLE
Fixed pwm resolution error

### DIFF
--- a/software/IOIOLib/src/ioio/lib/impl/PwmImpl.java
+++ b/software/IOIOLib/src/ioio/lib/impl/PwmImpl.java
@@ -93,7 +93,7 @@ class PwmImpl extends AbstractPin implements PwmOutput {
 			fraction = 0;
 		} else {
 			pw = (int) p;
-			fraction = ((int) p * 4) & 0x03;
+			fraction = (int)(p * 4) & 0x03;
 		}
 		try {
 			ioio_.protocol_.setPwmDutyCycle(pwm_.id, pw, fraction);


### PR DESCRIPTION
The parenthesis is at the wrong place. Therefore fraction is still 0.

[#109](https://github.com/ytai/ioio/pull/109) retargeted to master branch.