### PR TITLE
Changed inheritance from Activity to AppCompatActivity.

### DIFF
--- a/software/IOIOLibAndroid/build.gradle
+++ b/software/IOIOLibAndroid/build.gradle
@@ -18,4 +18,5 @@ android {
 
 dependencies {
     api project(":IOIOLibCore")
+    implementation 'androidx.appcompat:appcompat:1.2.0'
 }

--- a/software/IOIOLibAndroid/src/main/java/ioio/lib/util/android/IOIOActivity.java
+++ b/software/IOIOLibAndroid/src/main/java/ioio/lib/util/android/IOIOActivity.java
@@ -31,14 +31,15 @@ package ioio.lib.util.android;
 import ioio.lib.impl.SocketIOIOConnection;
 import ioio.lib.util.IOIOLooper;
 import ioio.lib.util.IOIOLooperProvider;
-import android.app.Activity;
+import androidx.appcompat.app.AppCompatActivity;
 import android.content.Intent;
 import android.os.Bundle;
+
 
 /**
  * A convenience class for easy creation of IOIO-based activities.
  * 
- * It is used by creating a concrete {@link Activity} in your application, which
+ * It is used by creating a concrete {@link AppCompatActivity} in your application, which
  * extends this class. This class then takes care of proper creation and
  * abortion of the IOIO connection and of a dedicated thread for IOIO
  * communication.
@@ -68,7 +69,7 @@ import android.os.Bundle;
  * example, in the case of {@link SocketIOIOConnection}, the second argument
  * will contain an {@link Integer} representing the local port number.
  */
-public abstract class IOIOActivity extends Activity implements
+public abstract class IOIOActivity extends AppCompatActivity implements
 		IOIOLooperProvider {
 	private final IOIOAndroidApplicationHelper helper_ = new IOIOAndroidApplicationHelper(
 			this, this);


### PR DESCRIPTION
Main motivation behind this change was to allow for plug-n-play with Google's MLKit sample code which require the base activity to be an AppCompatActivity. I had previously added a wrapped to the IOIOActivity class which implemented many of these requirements, but it was getting unwieldy.