### PR TITLE
Provide IOIOLibAndroid in any Android library

### DIFF
--- a/software/IOIOLibAndroidAccessory/build.gradle
+++ b/software/IOIOLibAndroidAccessory/build.gradle
@@ -21,5 +21,5 @@ uploadArchives {
 }
 
 dependencies {
-    implementation project(":IOIOLibAndroid")
+    api project(":IOIOLibAndroid")
 }

--- a/software/IOIOLibAndroidBluetooth/build.gradle
+++ b/software/IOIOLibAndroidBluetooth/build.gradle
@@ -17,5 +17,5 @@ uploadArchives {
 }
 
 dependencies {
-    implementation project(":IOIOLibAndroid")
+    api project(":IOIOLibAndroid")
 }

--- a/software/IOIOLibAndroidDevice/build.gradle
+++ b/software/IOIOLibAndroidDevice/build.gradle
@@ -17,5 +17,5 @@ uploadArchives {
 }
 
 dependencies {
-    implementation project(":IOIOLibAndroid")
+    api project(":IOIOLibAndroid")
 }


### PR DESCRIPTION
As result, there is no need  of 

```
dependencies {
    implementation project(':IOIOLibAndroid')
}
```

anymore, if you specify one of them

    implementation project(':IOIOLibAndroidBluetooth')
    implementation project(':IOIOLibAndroidAccessory')
    implementation project(':IOIOLibAndroidDevice')