### PR TITLE
Removed flavors from build.gradle of HelloIOIO

### DIFF
--- a/applications/HelloIOIO/build.gradle
+++ b/applications/HelloIOIO/build.gradle
@@ -22,27 +22,12 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
-    flavorDimensions "integration"
-    productFlavors {
-        code {
-            dimension "integration"
-        }
-        library {
-            dimension "integration"
-        }
-    }
-
 }
 
 dependencies {
-    codeImplementation project(':IOIOLibAndroidBluetooth')
-    codeImplementation project(':IOIOLibAndroidAccessory')
-    codeImplementation project(':IOIOLibAndroidDevice')
-
-    def ioioVersion = "6.0.0.beta8"
-    libraryImplementation "com.github.ytai.ioio:IOIOLibAndroidBluetooth:$ioioVersion"
-    libraryImplementation "com.github.ytai.ioio:IOIOLibAndroidAccessory:$ioioVersion"
-    libraryImplementation "com.github.ytai.ioio:IOIOLibAndroidDevice:$ioioVersion"
+    implementation project(':IOIOLibAndroidBluetooth')
+    implementation project(':IOIOLibAndroidAccessory')
+    implementation project(':IOIOLibAndroidDevice')
 
     androidTestImplementation 'com.github.AppDevNext:Moka:0.4'
     androidTestImplementation "androidx.test.ext:junit:1.1.2"

--- a/applications/HelloIOIO/src/androidTest/java/ioio/examples/hello/HelloIOIOSmokeTest.kt
+++ b/applications/HelloIOIO/src/androidTest/java/ioio/examples/hello/HelloIOIOSmokeTest.kt
@@ -27,6 +27,6 @@ class HelloIOIOSmokeTest {
     @Test
     fun smokeTestSimplyStart() {
         onView(withId(R.id.button)).check(matches(isDisplayed()))
-        Screenshot.takeScreenshot(BuildConfig.FLAVOR + "-smoke")
+        Screenshot.takeScreenshot(BuildConfig.APPLICATION_ID + "-smoke")
     }
 }


### PR DESCRIPTION
I didn't know what you wanted to rename the screenshots, but I can just remove the `BuildConfig.APPLICATION_ID` or whatever you prefer now that the FLAVOR attribute no longer exists. 

I'll work on the permanent theme changes after pulling this in and rebasing on this. 