### PR TITLE
Avoid a message on repo open

### DIFF
--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -15,3 +15,4 @@ jobs:
         uses: gradle-update/update-gradle-wrapper-action@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          set-distribution-checksum: false


### PR DESCRIPTION
It's about this https://github.com/ytai/ioio/pull/208#issuecomment-704698528

The first impression of this repo should not be a red warning. 
We should have a error and message free repo on first clone, open and start