### PR TITLE
Replaced assert statment with error check and AssertionError throw

### DIFF
--- a/IOIOLibCore/src/main/java/ioio/lib/api/PwmOutput.java
+++ b/IOIOLibCore/src/main/java/ioio/lib/api/PwmOutput.java
@@ -100,7 +100,7 @@ public interface PwmOutput extends Closeable {
      * @throws ConnectionLostException The connection to the IOIO has been lost.
      * @see #setPulseWidth(int)
      */
-    void setDutyCycle(float dutyCycle) throws ConnectionLostException, AssertionError;
+    void setDutyCycle(float dutyCycle) throws ConnectionLostException, RuntimeException;
 
     /**
      * Sets the pulse width of the PWM output. The pulse width is duration of
@@ -109,7 +109,7 @@ public interface PwmOutput extends Closeable {
      *
      * @param pulseWidthUs The pulse width, in microsecond units.
      * @throws ConnectionLostException The connection to the IOIO has been lost.
-     * @throws AssertionError dutyCycle must take values from 0 to 1 (inclusive).
+     * @throws RuntimeException dutyCycle must take values from 0 to 1 (inclusive).
      * @see #setDutyCycle(float)
      */
     void setPulseWidth(int pulseWidthUs) throws ConnectionLostException;

--- a/IOIOLibCore/src/main/java/ioio/lib/api/PwmOutput.java
+++ b/IOIOLibCore/src/main/java/ioio/lib/api/PwmOutput.java
@@ -108,17 +108,17 @@ public interface PwmOutput extends Closeable {
      * the high-time within a single period of the signal. For relative control
      * of the pulse with, consider using {@link #setDutyCycle(float)}.
      *
-     * @param pulseWidthUs The pulse width, in microsecond units.
+     * @param pulseWidthUs The pulse width, in microsecond units. Must be larger than zero.
      * @throws ConnectionLostException The connection to the IOIO has been lost.
      * @throws RuntimeException pulseWidthUs must take values larger than zero.
      * @see #setDutyCycle(float)
      */
-    void setPulseWidth(int pulseWidthUs) throws ConnectionLostException;
+    void setPulseWidth(int pulseWidthUs) throws ConnectionLostException, RuntimeException;
 
     /**
      * The same as {@link #setPulseWidth(int)}, but with sub-microsecond
      * precision.
      */
     void setPulseWidth(float pulseWidthUs)
-            throws ConnectionLostException;
+            throws ConnectionLostException, RuntimeException;
 }

--- a/IOIOLibCore/src/main/java/ioio/lib/api/PwmOutput.java
+++ b/IOIOLibCore/src/main/java/ioio/lib/api/PwmOutput.java
@@ -98,6 +98,7 @@ public interface PwmOutput extends Closeable {
      *
      * @param dutyCycle The duty cycle, as a real value from 0.0 to 1.0.
      * @throws ConnectionLostException The connection to the IOIO has been lost.
+     * @throws RuntimeException dutyCycle must take values from 0 to 1 (inclusive).
      * @see #setPulseWidth(int)
      */
     void setDutyCycle(float dutyCycle) throws ConnectionLostException, RuntimeException;
@@ -109,7 +110,7 @@ public interface PwmOutput extends Closeable {
      *
      * @param pulseWidthUs The pulse width, in microsecond units.
      * @throws ConnectionLostException The connection to the IOIO has been lost.
-     * @throws RuntimeException dutyCycle must take values from 0 to 1 (inclusive).
+     * @throws RuntimeException pulseWidthUs must take values larger than zero.
      * @see #setDutyCycle(float)
      */
     void setPulseWidth(int pulseWidthUs) throws ConnectionLostException;

--- a/IOIOLibCore/src/main/java/ioio/lib/api/PwmOutput.java
+++ b/IOIOLibCore/src/main/java/ioio/lib/api/PwmOutput.java
@@ -100,7 +100,7 @@ public interface PwmOutput extends Closeable {
      * @throws ConnectionLostException The connection to the IOIO has been lost.
      * @see #setPulseWidth(int)
      */
-    void setDutyCycle(float dutyCycle) throws ConnectionLostException;
+    void setDutyCycle(float dutyCycle) throws ConnectionLostException, AssertionError;
 
     /**
      * Sets the pulse width of the PWM output. The pulse width is duration of
@@ -109,6 +109,7 @@ public interface PwmOutput extends Closeable {
      *
      * @param pulseWidthUs The pulse width, in microsecond units.
      * @throws ConnectionLostException The connection to the IOIO has been lost.
+     * @throws AssertionError dutyCycle must take values from 0 to 1 (inclusive).
      * @see #setDutyCycle(float)
      */
     void setPulseWidth(int pulseWidthUs) throws ConnectionLostException;

--- a/IOIOLibCore/src/main/java/ioio/lib/impl/AnalogInputImpl.java
+++ b/IOIOLibCore/src/main/java/ioio/lib/impl/AnalogInputImpl.java
@@ -66,7 +66,9 @@ class AnalogInputImpl extends AbstractPin implements AnalogInput, InputPinListen
     @Override
     synchronized public void setValue(int value) {
         // Log.v("AnalogInputImpl", "Pin " + pinNum_ + " value is " + value);
-        assert (value >= 0 && value < 1024);
+        if (value < 0 || value >= 1024) {
+            throw new RuntimeException("value must be between 0 (inclusive) and 1024 (exclusive). A value of " + value + " was given.");
+        }
         value_ = value;
         ++sampleCount_;
         bufferPush((short) value);

--- a/IOIOLibCore/src/main/java/ioio/lib/impl/DigitalInputImpl.java
+++ b/IOIOLibCore/src/main/java/ioio/lib/impl/DigitalInputImpl.java
@@ -47,7 +47,9 @@ class DigitalInputImpl extends AbstractPin implements DigitalInput,
     @Override
     synchronized public void setValue(int value) {
         // Log.v("DigitalInputImpl", "Pin " + pinNum_ + " value is " + value);
-        assert (value == 0 || value == 1);
+        if (value != 0 && value != 1) {
+            throw new RuntimeException("value must be 0 or 1. A value of " + value + " was given.");
+        }
         value_ = (value == 1);
         if (!valid_) {
             valid_ = true;

--- a/IOIOLibCore/src/main/java/ioio/lib/impl/PwmImpl.java
+++ b/IOIOLibCore/src/main/java/ioio/lib/impl/PwmImpl.java
@@ -67,14 +67,16 @@ class PwmImpl extends AbstractPin implements PwmOutput {
     }
 
     @Override
-    public void setPulseWidth(int pulseWidthUs) throws ConnectionLostException {
+    public void setPulseWidth(int pulseWidthUs) throws ConnectionLostException, RuntimeException {
         setPulseWidth((float) pulseWidthUs);
     }
 
     @Override
     public void setPulseWidth(float pulseWidthUs)
-            throws ConnectionLostException {
-        assert (pulseWidthUs >= 0);
+            throws ConnectionLostException, RuntimeException {
+        if (pulseWidthUs < 0) {
+            throw new RuntimeException("pulseWidthUs must be larger than 0. A pulseWidthUs of " + pulseWidthUs + " was given.");
+        }
         float p = pulseWidthUs / baseUs_;
         setPulseWidthInClocks(p);
     }

--- a/IOIOLibCore/src/main/java/ioio/lib/impl/PwmImpl.java
+++ b/IOIOLibCore/src/main/java/ioio/lib/impl/PwmImpl.java
@@ -59,8 +59,8 @@ class PwmImpl extends AbstractPin implements PwmOutput {
     }
 
     @Override
-    public void setDutyCycle(float dutyCycle) throws ConnectionLostException {
-        assert (dutyCycle <= 1 && dutyCycle >= 0);
+    public void setDutyCycle(float dutyCycle) throws ConnectionLostException, AssertionError {
+        if (dutyCycle > 1 || dutyCycle < 0) throw new AssertionError("dutyCycle must be between 0 and 1");
         setPulseWidthInClocks(period_ * dutyCycle);
     }
 

--- a/IOIOLibCore/src/main/java/ioio/lib/impl/PwmImpl.java
+++ b/IOIOLibCore/src/main/java/ioio/lib/impl/PwmImpl.java
@@ -59,8 +59,10 @@ class PwmImpl extends AbstractPin implements PwmOutput {
     }
 
     @Override
-    public void setDutyCycle(float dutyCycle) throws ConnectionLostException, AssertionError {
-        if (dutyCycle > 1 || dutyCycle < 0) throw new AssertionError("dutyCycle must be between 0 and 1");
+    public void setDutyCycle(float dutyCycle) throws ConnectionLostException, RuntimeException {
+        if (dutyCycle > 1 || dutyCycle < 0) {
+            throw new RuntimeException("dutyCycle must be between 0 and 1. A dutyCycle of " + dutyCycle + " was given.");
+        }
         setPulseWidthInClocks(period_ * dutyCycle);
     }
 

--- a/applications/IOIOTortureTest/src/main/java/ioio/tests/torture/PwmTest.java
+++ b/applications/IOIOTortureTest/src/main/java/ioio/tests/torture/PwmTest.java
@@ -73,7 +73,7 @@ public class PwmTest implements Test<Boolean> {
     }
 
     private boolean runSingleTest(PwmOutput out, DigitalInput in, float dc)
-            throws InterruptedException, ConnectionLostException, AssertionError {
+            throws InterruptedException, ConnectionLostException, RuntimeException {
         out.setDutyCycle(dc);
         Thread.sleep(100);
         int highCount = 0;

--- a/applications/IOIOTortureTest/src/main/java/ioio/tests/torture/PwmTest.java
+++ b/applications/IOIOTortureTest/src/main/java/ioio/tests/torture/PwmTest.java
@@ -73,7 +73,7 @@ public class PwmTest implements Test<Boolean> {
     }
 
     private boolean runSingleTest(PwmOutput out, DigitalInput in, float dc)
-            throws InterruptedException, ConnectionLostException {
+            throws InterruptedException, ConnectionLostException, AssertionError {
         out.setDutyCycle(dc);
         Thread.sleep(100);
         int highCount = 0;


### PR DESCRIPTION
I noticed that sending incorrect values to the setDutyCycle method would fail silently and just hang at that point if called within an IOIOLooper instance. The error would not print to the logcat until the app was closed. As this took a fair bit of time to figure out, I figured I'd save others the time by replacing the silent assertion errors with a throw that should pop up in the logcat as soon as the error is encountered. 

Note, this is not the only location for these assert statements that I think should be replaced, but it is a start. I'm happy to make updates to some of the other assert statements I think could cause confusion for devs, but will wait to hear back on if this is a desired approach or not prior to putting in the effort. 

@hannesa2 as you are seem to know a lot more about formal coding practices than I, is this a legitimate method for solving these silent errors or do you recommend another way of approaching this? I'm essentially just following advice given [here](https://stackoverflow.com/questions/6176441/how-to-use-assert-in-android). 

If you think this is a valid approach, I can continue on this branch before merging and add a few more commits with other methods that rely on this silent assert keyword. 